### PR TITLE
Introducing a tag repository, with a few helpful methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,25 @@ Now, you can use TagManager.
     // Replace all current tags..
     $tags = $this->tagManager->loadOrCreateTags(array('Smallville', 'Superman'));
     $this->tagManager->replaceTags($tags, $article);
+
+### Tag-related queries
+
+The Tag entity has a repository class, with two particularly helpful methods:
+
+```php
+<?php
+
+    // somewhere crate or already have the entity manager
+    // $em = EntityManager::create($connection, $config);
+
+    $tagRepo = $em->getRepository('DoctrineExtensions\\Taggable\\Entity\\Tag');
+
+    // find all article ids matching a particular query
+    $ids = $tagRepo->getResourceIdsForTag('article_type', 'footag');
+
+    // get the tags and count for all articles
+    $tags = $tagRepo->getTagsWithCountArray('article_type');
+    foreach ($tags as $name => $count) {
+        echo sprintf('The tag "%s" matches "%s" articles', $name, $count);
+    }
+```

--- a/lib/DoctrineExtensions/Taggable/Entity/TagRepository.php
+++ b/lib/DoctrineExtensions/Taggable/Entity/TagRepository.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace DoctrineExtensions\Taggable\Entity;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\AbstractQuery;
+
+/**
+ * Common query-related methods for returning tag information
+ *
+ * @author Ryan Weaver <ryan@knplabs.com>
+ */
+class TagRepository extends EntityRepository
+{
+    /**
+     * The field that's considered the "lookup" for tags
+     *
+     * @var string
+     */
+    protected $tagQueryField = 'name';
+
+    /**
+     * For a specific taggable type, this returns an array where they key
+     * is the tag and the value is the number of times that tag is used
+     *
+     * @param string $taggableType The taggable type / resource type
+     * @param null|integer $limit The max results to return
+     * @return array
+     */
+    public function getTagsWithCountArray($taggableType, $limit = null)
+    {
+        $qb = $this->getTagsWithCountArrayQueryBuilder($taggableType);
+
+        if (null !== $limit) {
+            $qb->setMaxResults($limit);
+        }
+
+        $tags = $qb->getQuery()
+            ->getResult(AbstractQuery::HYDRATE_SCALAR)
+        ;
+
+        $arr = array();
+        foreach ($tags as $tag) {
+            $count = $tag['tag_count'];
+
+            // don't include orphaned tags
+            if ($count > 0) {
+                $tagName = $tag[$this->tagQueryField];
+                $arr[$tagName] = $count;
+            }
+        }
+
+        return $arr;
+    }
+
+    /**
+     * Returns an array of ids (e.g. Post ids) for a given taggable
+     * type that have the given tag
+     *
+     * @param string $taggableType The type of object we're looking for
+     * @param string $tag The actual tag we're looking for
+     * @return array
+     */
+    public function getResourceIdsForTag($taggableType, $tag)
+    {
+        $results = $this->getTagsQueryBuilder($taggableType)
+            ->andWhere('tag.'.$this->tagQueryField.' = :tag')
+            ->setParameter('tag', $tag)
+            ->select('tagging.resourceId')
+            ->getQuery()
+            ->execute(array(), AbstractQuery::HYDRATE_SCALAR)
+        ;
+
+        $ids = array();
+        foreach ($results as $result) {
+            $ids[] = $result['resourceId'];
+        }
+
+        return $ids;
+    }
+
+    /**
+     * Returns a query builder built to return tag counts for a given type
+     *
+     * @see getTagsWithCountArray
+     * @param $taggableType
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    public function getTagsWithCountArrayQueryBuilder($taggableType)
+    {
+        $qb = $this->getTagsQueryBuilder($taggableType)
+            ->groupBy('tagging.tag')
+            ->select('tag.'.$this->tagQueryField.', COUNT(tagging.tag) as tag_count')
+        ;
+
+        return $qb;
+    }
+
+    /**
+     * Returns a query builder returning tags for a given type
+     *
+     * @param string $taggableType
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    public function getTagsQueryBuilder($taggableType)
+    {
+        return $this->createQueryBuilder('tag')
+            ->join('tag.tagging', 'tagging')
+            ->where('tagging.resourceType = :resourceType')
+            ->setParameter('resourceType', $taggableType)
+        ;
+    }
+}

--- a/lib/DoctrineExtensions/Taggable/Entity/TagRepository.php
+++ b/lib/DoctrineExtensions/Taggable/Entity/TagRepository.php
@@ -91,6 +91,7 @@ class TagRepository extends EntityRepository
         $qb = $this->getTagsQueryBuilder($taggableType)
             ->groupBy('tagging.tag')
             ->select('tag.'.$this->tagQueryField.', COUNT(tagging.tag) as tag_count')
+            ->orderBy('tag_count', 'DESC')
         ;
 
         return $qb;

--- a/metadata/DoctrineExtensions.Taggable.Entity.Tag.dcm.xml
+++ b/metadata/DoctrineExtensions.Taggable.Entity.Tag.dcm.xml
@@ -4,7 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                   http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="DoctrineExtensions\Taggable\Entity\Tag">
+    <entity name="DoctrineExtensions\Taggable\Entity\Tag" repository-class="DoctrineExtensions\Taggable\Entity\TagRepository">
 
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />

--- a/tests/DoctrineExtensions/Taggable/Entity/TagRepositoryTest.php
+++ b/tests/DoctrineExtensions/Taggable/Entity/TagRepositoryTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace DoctrineExtensions\Taggable\Entity;
+
+use Tests\DoctrineExtensions\Taggable\Fixtures\Article;
+use DoctrineExtensions\Taggable\TagManager;
+use DoctrineExtensions\Taggable\TagListener;
+
+/**
+ * @author Ryan Weaver <ryan@knplabs.com>
+ */
+class TagRepositoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    protected $em;
+
+    /**
+     * @var \FPN\TagBundle\Entity\TagManager
+     */
+    protected $manager;
+
+    public function setUp()
+    {
+        $config = new \Doctrine\ORM\Configuration();
+        $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache);
+        $config->setQueryCacheImpl(new \Doctrine\Common\Cache\ArrayCache);
+        $config->setProxyDir(__DIR__ . '/Proxy');
+        $config->setProxyNamespace('DoctrineExtensions\Taggable\Proxies');
+
+        $driverImpl = new \Doctrine\ORM\Mapping\Driver\DriverChain();
+        $driverImpl->addDriver(new \Doctrine\ORM\Mapping\Driver\XmlDriver(__DIR__.'/../../../../metadata'), 'DoctrineExtensions\\Taggable\\Entity');
+        $driverImpl->addDriver($config->newDefaultAnnotationDriver(), 'Tests\\DoctrineExtensions\\Taggable\\Fixtures');
+        $config->setMetadataDriverImpl($driverImpl);
+
+        $this->em = \Doctrine\ORM\EntityManager::create(
+            array('driver' => 'pdo_sqlite', 'memory' => true),
+            $config
+        );
+
+
+        $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($this->em);
+        $schemaTool->dropSchema(array());
+        $schemaTool->createSchema(array(
+            $this->em->getClassMetadata('DoctrineExtensions\\Taggable\\Entity\\Tag'),
+            $this->em->getClassMetadata('DoctrineExtensions\\Taggable\\Entity\\Tagging'),
+            $this->em->getClassMetadata('Tests\\DoctrineExtensions\\Taggable\\Fixtures\\Article'),
+        ));
+
+        $this->manager = new TagManager($this->em);
+        $this->em->getEventManager()->addEventSubscriber(new TagListener($this->manager));
+    }
+
+    public function testGetTagsWithCountArray()
+    {
+        $this->loadFixtures();
+
+        $tags = $this->getTagRepository()->getTagsWithCountArray('test-article');
+
+        $this->assertEquals(array(
+            'alltag' => 3,
+            'tag3'   => 2,
+            'tag1'   => 1,
+            'tag2'   => 1,
+        ), $tags);
+    }
+
+    public function testGetResourceIdsForTag()
+    {
+        $this->loadFixtures();
+
+        // articles named tag3 and tag4 have the tag3 tag
+        $tag3 = $this->getArticleRepository()->findOneBy(array('title' => 'My 3 article'));
+        $tag4 = $this->getArticleRepository()->findOneBy(array('title' => 'My 4 article'));
+
+        $ids = $this->getTagRepository()->getResourceIdsForTag('test-article', 'tag3');
+        $this->assertEquals(array($tag3->getId(), $tag4->getId()), $ids);
+    }
+
+    /**
+     * @return \DoctrineExtensions\Taggable\Entity\TagRepository
+     */
+    private function getTagRepository()
+    {
+        return $this->em
+            ->getRepository('DoctrineExtensions\\Taggable\\Entity\\Tag')
+        ;
+    }
+
+    /**
+     * @return \Doctrine\ORM\EntityRepository
+     */
+    private function getArticleRepository()
+    {
+        return $this->em
+            ->getRepository('Tests\\DoctrineExtensions\\Taggable\\Fixtures\\Article')
+        ;
+    }
+
+    /**
+     * Loads in some dummy articles with tags so we can test against it.
+     *
+     * Articles:
+     *
+     *  My 1 article => array(tag1, alltag)
+     *  My 2 article => array(tag2, alltag)
+     *  My 3 article => array(tag3, alltag)
+     *  My 4 article => array(tag3)
+     *
+     *
+     * @return void
+     */
+    private function loadFixtures()
+    {
+        $tagAll = $this->manager->loadOrCreateTag('alltag');
+        $tags = array();
+        $allArticles = array();
+
+        for ($i = 1; $i <= 4; $i++) {
+            $article = new Article();
+            $article->setTitle('My '.$i.' article');
+            $allArticles[] = $article;
+
+            $this->em->persist($article);
+
+            $tags[$i] = $this->manager->loadOrCreateTag('tag'.$i);
+            $tags[$i]->setName('tag'.$i);
+
+            if ($i != 4) {
+                // give them their own tag and the all tag
+                $this->manager->addTag($tags[$i], $article);
+                $this->manager->addTag($tagAll, $article);
+            } else {
+                // does't get its own tag, but get's 3's tag
+                $this->manager->addTag($tags[3], $article);
+            }
+        }
+
+        $this->em->flush();
+
+        // save the tagging after everything's been flushed
+        foreach ($allArticles as $article) {
+            $this->manager->saveTagging($article);
+        }
+    }
+}


### PR DESCRIPTION
Hey Fabien!

This repository should be generic enough, and hopefully quite helpful. It's probably not perfect, but a good start. A few comments:
- I'm not exactly sure why we have the "name" field in the extension, but then a "slug" field in the bundle. I understand the idea of normalizing all the tags, but it seems like we should do that in the extension (not just in the bundle). To allow the bundle to work later, I've added a `tagQueryField` property to the `TagRepository` so that we eventually create a `TagRepository` in the bundle, which subclasses this one and changes that property to `slug`.
- As mentioned above, once we're happy with this, some changes should be made to the bundle (and its documentation) so that this works easily there as well.

Thanks!
