### PR TITLE
Prevent a query syntax error by checking for an empty tag array

### DIFF
--- a/lib/DoctrineExtensions/Taggable/TagManager.php
+++ b/lib/DoctrineExtensions/Taggable/TagManager.php
@@ -105,6 +105,10 @@ class TagManager
      */
     public function loadOrCreateTags(array $names)
     {
+        if (empty($names)) {
+            return array();
+        }
+
         $names = array_unique($names);
 
         $builder = $this->em->createQueryBuilder();


### PR DESCRIPTION
Hey Fabien!

If you let this method create the query with an empty array, it results in a syntax error. This prevents that.

Thanks!
