### PR TITLE
Refactor to use tag strings or tag objects

### DIFF
--- a/lib/DoctrineExtensions/Taggable/Taggable.php
+++ b/lib/DoctrineExtensions/Taggable/Taggable.php
@@ -30,11 +30,4 @@ interface Taggable
      * @return string
      */
     function getTaggableId();
-
-    /**
-     * Returns the collection of tags for this Taggable entity
-     *
-     * @return Doctrine\Common\Collections\Collection
-     */
-    function getTags();
 }

--- a/lib/DoctrineExtensions/Taggable/TaggableObjectInterface.php
+++ b/lib/DoctrineExtensions/Taggable/TaggableObjectInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Extensions Taggable package.
+ * (c) 2011 Fabien Pennequin <fabien@pennequin.me>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineExtensions\Taggable;
+
+/**
+ * An optional interface that allows you to work with a tag string instead
+ * of Tag objects
+ *
+ * @author Ryan Weaver <ryan@knplabs.com>
+ */
+interface TaggableObjectInterface extends Taggable
+{
+    /**
+     * Returns the collection of tags for this Taggable entity
+     *
+     * @return Doctrine\Common\Collections\Collection
+     */
+    function getTags();
+}
+

--- a/lib/DoctrineExtensions/Taggable/TaggableStringInterface.php
+++ b/lib/DoctrineExtensions/Taggable/TaggableStringInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Extensions Taggable package.
+ * (c) 2011 Fabien Pennequin <fabien@pennequin.me>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineExtensions\Taggable;
+
+/**
+ * An optional interface that allows you to work with a tag string instead
+ * of Tag objects
+ *
+ * @author Ryan Weaver <ryan@knplabs.com>
+ */
+interface TaggableStringInterface extends Taggable
+{
+    /**
+     * Returns the comma-separated tag string
+     *
+     * @return string
+     */
+    function getTagString();
+
+    /**
+     * Sets the comma-separated tag string on this object
+     *
+     * @param string $tagString The comma-separated tags string
+     */
+    function setTagString($tagString);
+}
+

--- a/tests/DoctrineExtensions/Taggable/Entity/TagRepositoryTest.php
+++ b/tests/DoctrineExtensions/Taggable/Entity/TagRepositoryTest.php
@@ -2,7 +2,7 @@
 
 namespace DoctrineExtensions\Taggable\Entity;
 
-use Tests\DoctrineExtensions\Taggable\Fixtures\Article;
+use Tests\DoctrineExtensions\Taggable\Fixtures\TaggableObjectArticle as Article;
 use DoctrineExtensions\Taggable\TagManager;
 use DoctrineExtensions\Taggable\TagListener;
 
@@ -45,7 +45,7 @@ class TagRepositoryTest extends \PHPUnit_Framework_TestCase
         $schemaTool->createSchema(array(
             $this->em->getClassMetadata('DoctrineExtensions\\Taggable\\Entity\\Tag'),
             $this->em->getClassMetadata('DoctrineExtensions\\Taggable\\Entity\\Tagging'),
-            $this->em->getClassMetadata('Tests\\DoctrineExtensions\\Taggable\\Fixtures\\Article'),
+            $this->em->getClassMetadata('Tests\\DoctrineExtensions\\Taggable\\Fixtures\\TaggableObjectArticle'),
         ));
 
         $this->manager = new TagManager($this->em);
@@ -96,7 +96,7 @@ class TagRepositoryTest extends \PHPUnit_Framework_TestCase
     private function getArticleRepository()
     {
         return $this->em
-            ->getRepository('Tests\\DoctrineExtensions\\Taggable\\Fixtures\\Article')
+            ->getRepository('Tests\\DoctrineExtensions\\Taggable\\Fixtures\\TaggableObjectArticle')
         ;
     }
 
@@ -131,11 +131,11 @@ class TagRepositoryTest extends \PHPUnit_Framework_TestCase
 
             if ($i != 4) {
                 // give them their own tag and the all tag
-                $this->manager->addTag($tags[$i], $article);
-                $this->manager->addTag($tagAll, $article);
+                $article->getTags()->add($tags[$i]);
+                $article->getTags()->add($tagAll);
             } else {
                 // does't get its own tag, but get's 3's tag
-                $this->manager->addTag($tags[3], $article);
+                $article->getTags()->add($tags[3]);
             }
         }
 

--- a/tests/DoctrineExtensions/Taggable/Entity/TaggingTest.php
+++ b/tests/DoctrineExtensions/Taggable/Entity/TaggingTest.php
@@ -8,12 +8,12 @@
  * file that was distributed with this source code.
  */
 
-require_once __DIR__.'/../Fixtures/Article.php';
+require_once __DIR__.'/../Fixtures/TaggableObjectArticle.php';
 
 use DoctrineExtensions\Taggable\Entity\Tagging;
 use DoctrineExtensions\Taggable\Entity\Tag;
 
-use Tests\DoctrineExtensions\Taggable\Fixtures\Article;
+use Tests\DoctrineExtensions\Taggable\Fixtures\TaggableObjectArticle as Article;
 
 class TaggingTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/DoctrineExtensions/Taggable/Fixtures/TaggableObjectArticle.php
+++ b/tests/DoctrineExtensions/Taggable/Fixtures/TaggableObjectArticle.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\DoctrineExtensions\Taggable\Fixtures;
+
+use DoctrineExtensions\Taggable\TaggableObjectInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ */
+class TaggableObjectArticle implements TaggableObjectInterface
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @Column(name="title", type="string", length=50)
+     */
+    public $title;
+
+    protected $tags;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        return $this->title = $title;
+    }
+
+    public function getTaggableType()
+    {
+        return 'test-article';
+    }
+
+    public function getTaggableId()
+    {
+        return $this->getId();
+    }
+
+    public function getTags()
+    {
+        $this->tags = $this->tags ?: new ArrayCollection();
+        return $this->tags;
+    }
+
+    public function setTags(ArrayCollection $tags)
+    {
+        $this->tags = $tags;
+    }
+}

--- a/tests/DoctrineExtensions/Taggable/Fixtures/TaggableStringArticle.php
+++ b/tests/DoctrineExtensions/Taggable/Fixtures/TaggableStringArticle.php
@@ -2,13 +2,13 @@
 
 namespace Tests\DoctrineExtensions\Taggable\Fixtures;
 
-use DoctrineExtensions\Taggable\Taggable;
+use DoctrineExtensions\Taggable\TaggableStringInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * @Entity
  */
-class Article implements Taggable
+class TaggableStringArticle implements TaggableStringInterface
 {
     /**
      * @Id
@@ -24,6 +24,8 @@ class Article implements Taggable
 
     protected $tags;
 
+    protected $tagString;
+
     public function getId()
     {
         return $this->id;
@@ -36,7 +38,7 @@ class Article implements Taggable
 
     public function getTaggableType()
     {
-        return 'test-article';
+        return 'test-article-with-tag-string';
     }
 
     public function getTaggableId()
@@ -44,9 +46,13 @@ class Article implements Taggable
         return $this->getId();
     }
 
-    public function getTags()
+    public function getTagString()
     {
-        $this->tags = $this->tags ?: new ArrayCollection();
-        return $this->tags;
+        return $this->tagString;
+    }
+
+    public function setTagString($tagString)
+    {
+        $this->tagString = $tagString;
     }
 }

--- a/tests/DoctrineExtensions/Taggable/TagManagerTest.php
+++ b/tests/DoctrineExtensions/Taggable/TagManagerTest.php
@@ -8,12 +8,14 @@
  * file that was distributed with this source code.
  */
 
-require_once __DIR__.'/Fixtures/Article.php';
+require_once __DIR__.'/Fixtures/TaggableObjectArticle.php';
+require_once __DIR__.'/Fixtures/TaggableStringArticle.php';
 
 use DoctrineExtensions\Taggable\TagManager;
 use DoctrineExtensions\Taggable\TagListener;
 use DoctrineExtensions\Taggable\Entity\Tag;
-use Tests\DoctrineExtensions\Taggable\Fixtures\Article;
+use Tests\DoctrineExtensions\Taggable\Fixtures\TaggableObjectArticle;
+use Tests\DoctrineExtensions\Taggable\Fixtures\TaggableStringArticle;
 
 
 class TagManagerTest extends \PHPUnit_Framework_TestCase
@@ -47,7 +49,8 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
         $schemaTool->createSchema(array(
             $this->em->getClassMetadata('DoctrineExtensions\\Taggable\\Entity\\Tag'),
             $this->em->getClassMetadata('DoctrineExtensions\\Taggable\\Entity\\Tagging'),
-            $this->em->getClassMetadata('Tests\\DoctrineExtensions\\Taggable\\Fixtures\\Article'),
+            $this->em->getClassMetadata('Tests\\DoctrineExtensions\\Taggable\\Fixtures\\TaggableObjectArticle'),
+            $this->em->getClassMetadata('Tests\\DoctrineExtensions\\Taggable\\Fixtures\\TaggableStringArticle'),
         ));
 
         $this->manager = new TagManager($this->em);
@@ -61,102 +64,6 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
     {
         $manager = new TagManager($this->em);
         $this->assertInstanceOf('DoctrineExtensions\Taggable\TagManager', $manager);
-    }
-
-    /**
-     * @covers DoctrineExtensions\Taggable\TagManager::addTag
-     */
-    public function testAddTag()
-    {
-        $article = new Article();
-        $article->setTitle('Test adding a tag...');
-
-        $tag = new Tag('Doctrine2');
-        $this->manager->addTag($tag, $article);
-
-        $this->assertEquals(1, $article->getTags()->count());
-
-        $firstTag = $article->getTags()->get(0);
-        $this->assertInstanceOf('DoctrineExtensions\Taggable\Entity\Tag', $firstTag);
-        $this->assertEquals($tag, $firstTag);
-    }
-
-    /**
-     * @covers DoctrineExtensions\Taggable\TagManager::addTags
-     */
-    public function testAddTags()
-    {
-        $article = new Article();
-        $article->setTitle('Test adding a tag...');
-
-        $tag1 = new Tag('Doctrine2');
-        $tag2 = new Tag('Symfony2');
-        $tag3 = new Tag('PHP 5.3');
-        $this->manager->addTags(array($tag1, 'tag', $tag2, $tag3), $article);
-
-        $this->assertEquals(3, $article->getTags()->count());
-        $this->assertEquals(array($tag1, $tag2, $tag3), $article->getTags()->toArray());
-
-    }
-
-    /**
-     * @covers DoctrineExtensions\Taggable\TagManager::removeTag
-     */
-    public function testRemoveTag()
-    {
-        $tag1 = new Tag('Doctrine2');
-        $tag2 = new Tag('Testing');
-        $tag3 = new Tag('Symfony2');
-
-        $article = new Article();
-        $article->setTitle('Test removing a tag...');
-
-        $this->manager->addTag($tag1, $article);
-        $this->manager->addTag($tag2, $article);
-        $this->manager->addTag($tag3, $article);
-
-        $this->assertEquals(3, $article->getTags()->count());
-
-        $this->manager->removeTag($tag2, $article);
-        $this->assertEquals(2, $article->getTags()->count());
-        $this->assertEquals($tag1, $article->getTags()->get(0));
-        $this->assertNull($article->getTags()->get(1));
-        $this->assertEquals($tag3, $article->getTags()->get(2));
-
-        $this->manager->removeTag($tag2, $article);
-        $this->assertEquals(2, $article->getTags()->count());
-
-        $this->manager->removeTag($tag1, $article);
-        $this->assertEquals(1, $article->getTags()->count());
-
-        $this->manager->removeTag($tag3, $article);
-        $this->assertEquals(0, $article->getTags()->count());
-    }
-
-    /**
-     * @covers DoctrineExtensions\Taggable\TagManager::replaceTags
-     */
-    public function testReplaceTags()
-    {
-        $tag1 = new Tag('Smallville');
-        $tag2 = new Tag('Superman');
-        $tag3 = new Tag('TV');
-
-        $article = new Article();
-        $article->setTitle('Test removing a tag...');
-
-        $tags1 = array($tag1, $tag2, $tag3);
-        $this->manager->addTags($tags1, $article);
-        $this->assertEquals(3, $article->getTags()->count());
-        $this->assertEquals($tags1, $article->getTags()->toArray());
-
-        $tag4 = new Tag('Clark Kent');
-        $tag5 = new Tag('Loïs Lane');
-
-        $tags2 = array($tag1, $tag3, $tag4, $tag5);
-        $this->manager->replaceTags($tags2, $article);
-        $this->assertEquals(4, $article->getTags()->count());
-        $this->assertEquals($tags2, $article->getTags()->toArray());
     }
 
     /**
@@ -182,7 +89,7 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
         $tagNames = array('Smallville', 'Superman', 'Smallville', 'TV');
         $tags = $this->manager->loadOrCreateTags($tagNames);
 
-        $this->assertInternalType('array', $tags);
+        $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $tags);
         $this->assertEquals(3, sizeof($tags));
 
         $this->assertInstanceOf('DoctrineExtensions\Taggable\Entity\Tag', $tags[0]);
@@ -201,9 +108,9 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
 
 
         $tagNames = array('Smallville');
-        $this->assertEquals(array($tags[0]), $this->manager->loadOrCreateTags($tagNames));
+        $this->assertEquals($tags[0], $this->manager->loadOrCreateTags($tagNames)->first());
 
-        $this->assertEquals(array(), $this->manager->loadOrCreateTags(array()));
+        $this->assertEquals(0, count($this->manager->loadOrCreateTags(array())));
     }
 
     /**
@@ -215,21 +122,21 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
     public function testSaveLoadTagging()
     {
         $title = 'Testing...';
-        $article = new Article();
+        $article = new TaggableObjectArticle();
         $article->setTitle($title);
 
         $this->em->persist($article);
         $this->em->flush();
 
         $tags1 = $this->manager->loadOrCreateTags(array('Smallville', 'Superman', 'TV'));
-        $this->manager->addTags($tags1, $article);
+        $article->setTags($tags1);
         $this->manager->saveTagging($article);
 
         unset($article);
         $this->em->clear();
 
         $loadedArticle = $this->em
-            ->getRepository('Tests\DoctrineExtensions\Taggable\Fixtures\Article')
+            ->getRepository('Tests\DoctrineExtensions\Taggable\Fixtures\TaggableObjectArticle')
             ->findOneBy(array('title' => $title));
 
         $this->assertNotNull($loadedArticle);
@@ -244,7 +151,7 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
 
         $article = $loadedArticle;
         $tags2 = $this->manager->loadOrCreateTags(array('Smallville', 'TV', 'Clark Kent', 'Loïs Lane'));
-        $this->manager->replaceTags($tags2, $article);
+        $article->setTags($tags2);
         $this->manager->saveTagging($article);
 
         $this->manager->loadTagging($article);
@@ -253,6 +160,27 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($tags2[1]->getId(), $loadedArticle->getTags()->get(1)->getId());
         $this->assertEquals($tags2[2]->getId(), $loadedArticle->getTags()->get(2)->getId());
         $this->assertEquals($tags2[3]->getId(), $loadedArticle->getTags()->get(3)->getId());
+
+        // test a TagStringInterface entity
+        $title = 'Testing-tag-string';
+        $article = new TaggableStringArticle();
+        $article->setTitle($title);
+
+        $this->em->persist($article);
+        $this->em->flush();
+
+        $article->setTagString('Foo, Bar');
+        $this->manager->saveTagging($article);
+
+        unset($article);
+        $this->em->clear();
+
+        $loadedArticle = $this->em
+            ->getRepository('Tests\DoctrineExtensions\Taggable\Fixtures\TaggableStringArticle')
+            ->findOneBy(array('title' => $title));
+
+        $this->manager->loadTagging($loadedArticle);
+        $this->assertEquals('Foo, Bar', $loadedArticle->getTagString());
     }
 
     public function testDeleteResource()
@@ -263,14 +191,14 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
         $tagRepository = $this->em
             ->getRepository('DoctrineExtensions\Taggable\Entity\Tag');
 
-        $article = new Article();
+        $article = new TaggableObjectArticle();
         $article->setTitle('Testing...');
 
         $this->em->persist($article);
         $this->em->flush();
 
         $tags = $this->manager->loadOrCreateTags(array('Smallville', 'Superman', 'TV'));
-        $this->manager->addTags($tags, $article);
+        $article->setTags($tags);
         $this->manager->saveTagging($article);
 
         $this->assertEquals(3, sizeof($taggingRepository->findAll()));
@@ -303,18 +231,19 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetTagNames()
     {
-        $article = new Article();
+        $article = new TaggableObjectArticle();
         $article->setTitle('Unit Test');
 
         $this->assertEquals(array(), $this->manager->getTagNames($article));
 
         $tag1 = new Tag('Smallville');
-        $this->manager->addTag($tag1, $article);
+        $article->getTags()->add($tag1);
         $this->assertEquals(array('Smallville'), $this->manager->getTagNames($article));
 
         $tag2 = new Tag('Superman');
         $tag3 = new Tag('TV');
-        $this->manager->addTags(array($tag2, $tag3), $article);
+        $article->getTags()->add($tag2);
+        $article->getTags()->add($tag3);
         $this->assertEquals(array('Smallville', 'Superman', 'TV'), $this->manager->getTagNames($article));
     }
 


### PR DESCRIPTION
Hey Fabien!

This is up for discussion, and obviously the docs would need to be greatly updated and this breaks BC. Fortunately, I think we may be the only two people using this extension... for now. My hope is that we can make the extension even easier to use and more people will hop on.

Anyways, this separates the interfaces into 2 usable interfaces (and a base interface). One allows you to use the extension just like before - by dealing directly with the Tag objects. The other, however, allows you to interact directly with a comma-separated tag string instead.

I think the architecture with the if statements near the bottom of the `TagManager` to check for the interface are a bit messy, but quite functional - I don't really see the need to abstract further right now. Also, I realize that I've hardcoded the comma as being the tag string separator, with no way to override this. If you can think of a good solution, let me know. I'd rather not require another method (e.g. `getTagSeparator`) on the `TaggableStringInterface` if we don't have to.

Oh, also, `loadOrCreateTags` now returns an `ArrayCollection` instead of an array. This makes it easier to get a result directly from that method and set it on your resource, since the `addTags()` method on the manager is now gone.

Thanks!
