### PR TITLE
saveTagging method in TagManager issue

### DIFF
--- a/lib/DoctrineExtensions/Taggable/TagManager.php
+++ b/lib/DoctrineExtensions/Taggable/TagManager.php
@@ -173,6 +173,10 @@ class TagManager
                     ->delete($this->taggingClass, 't')
                     ->where('t.tag_id')
                     ->where($builder->expr()->in('t.tag', $tagsToRemove))
+                    ->andWhere('t.resourceType = :resourceType')
+                    ->setParameter('resourceType', $resource->getTaggableType())
+                    ->andWhere('t.resourceId = :resourceId')
+                    ->setParameter('resourceId', $resource->getTaggableId())
                     ->getQuery()
                     ->getResult()
                 ;


### PR DESCRIPTION
Hi,
I found an issue in saveTagging method of the TagManager. All tagging with a tag_id were deleted by the doctrine query. But only the resource's tagging must be deleted.
Therefor, I added some conditions in "where" clause to fix this issue.
