### PR TITLE
Storing metadata with the tagging object

### DIFF
--- a/lib/DoctrineExtensions/Taggable/Entity/Tag.php
+++ b/lib/DoctrineExtensions/Taggable/Entity/Tag.php
@@ -106,4 +106,17 @@ class Tag
     {
         return $this->metadata;
     }
+    
+    /**
+     * Returns tag's Metadata object (if exists)
+     *
+     * @return string
+     */
+    public function getMetadata($name)
+    {
+        $function = "getMetadata".$name;
+        return $this->getTagging()->current()->$function();
+    }
+    
+    
 }

--- a/lib/DoctrineExtensions/Taggable/Entity/Tag.php
+++ b/lib/DoctrineExtensions/Taggable/Entity/Tag.php
@@ -21,6 +21,8 @@ class Tag
     protected $updatedAt;
 
     protected $tagging;
+    
+    protected $metadata; //Not an existing column in the database, here for storage.
 
 
     /**
@@ -83,5 +85,25 @@ class Tag
     public function getUpdatedAt()
     {
         return $this->updatedAt;
+    }
+    
+    /**
+     * Sets the tag's Metadata object
+     *
+     * @param string $name Name to set
+     */
+    public function setTagMetadata($metadata)
+    {
+        $this->metadata = $metadata;
+    }
+
+    /**
+     * Returns tag's Metadata object (if exists)
+     *
+     * @return string
+     */
+    public function getTagMetadata()
+    {
+        return $this->metadata;
     }
 }

--- a/lib/DoctrineExtensions/Taggable/Entity/TagMetadata.php
+++ b/lib/DoctrineExtensions/Taggable/Entity/TagMetadata.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Extensions Taggable package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineExtensions\Taggable\Entity;
+
+use DoctrineExtensions\Taggable\Taggable;
+
+class TagMetadata
+{
+
+    protected $data;
+    
+    public function __construct() 
+    { 
+        $this->data = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+    
+    public function getData() 
+    { 
+        return $this->data;
+    }
+
+    public function add($name, $value)
+    {
+        $this->getData()->add(array("name" => $name, "value" => $value));
+    } 
+    
+    public function dump() 
+    { 
+        return $this->data;
+    }
+
+}
+
+?>

--- a/lib/DoctrineExtensions/Taggable/Entity/TagMetadata.php
+++ b/lib/DoctrineExtensions/Taggable/Entity/TagMetadata.php
@@ -16,21 +16,40 @@ class TagMetadata
 
     protected $data;
     
+    /**
+     * Constructor
+     */
     public function __construct() 
     { 
         $this->data = new \Doctrine\Common\Collections\ArrayCollection();
     }
     
+    /**
+     * Returns the $data ArrayCollection
+     *
+     * @return ArrayCollection
+     */
     public function getData() 
     { 
         return $this->data;
     }
-
+    
+    /**
+     * Adds tag metadata to the data ArrayCollection
+     *
+     * @param string $name Name of the Metadata field
+     * @param mixed $value The value to store
+     */
     public function add($name, $value)
     {
         $this->getData()->add(array("name" => $name, "value" => $value));
     } 
     
+    /**
+     * Returns the $data ArrayCollection
+     *
+     * @return ArrayCollection
+     */
     public function dump() 
     { 
         return $this->data;

--- a/lib/DoctrineExtensions/Taggable/Entity/Tagging.php
+++ b/lib/DoctrineExtensions/Taggable/Entity/Tagging.php
@@ -27,7 +27,7 @@ class Tagging
     /**
      * Constructor
      */
-    public function __construct(Tag $tag = null, Taggable $resource = null)
+    public function __construct(Tag $tag = null, Taggable $resource = null, array $metadata = null)
     {
         if ($tag != null) {
             $this->setTag($tag);

--- a/lib/DoctrineExtensions/Taggable/TagManager.php
+++ b/lib/DoctrineExtensions/Taggable/TagManager.php
@@ -331,7 +331,7 @@ class TagManager
     }
 
     /**
-     * Creates a new Tagging object
+     * Creates a new Tagging object and sets metadata (if applicable)
      *
      * @param Tag       $tag        Tag object
      * @param Taggable  $resource   Taggable resource object

--- a/lib/DoctrineExtensions/Taggable/TagManager.php
+++ b/lib/DoctrineExtensions/Taggable/TagManager.php
@@ -215,6 +215,7 @@ class TagManager
             ->createQueryBuilder()
 
             ->select('t')
+            ->addSelect('t2')
             ->from($this->tagClass, 't')
 
             ->innerJoin('t.tagging', 't2', Expr\Join::WITH, 't2.resourceId = :id AND t2.resourceType = :type')

--- a/lib/DoctrineExtensions/Taggable/TagManager.php
+++ b/lib/DoctrineExtensions/Taggable/TagManager.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\Commons\Collections\Collection;
 use DoctrineExtensions\Taggable\Entity\Tag;
+use DoctrineExtensions\Taggable\Entity\TagMetadata;
 use DoctrineExtensions\Taggable\Entity\Tagging;
 
 /**
@@ -45,6 +46,20 @@ class TagManager
     {
         $resource->getTags()->add($tag);
     }
+    
+    /**
+     * Adds a tag (and temporarily stores metadata to it)
+     * on the given taggable resource.
+     *
+     * @param Tag       $tag        Tag object
+     * @param Metadata  $metadata   TagMetadata object
+     * @param Taggable  $resource   Taggable resource
+     */
+    public function addTagWithMetadata(Tag $tag, TagMetadata $metadata, Taggable $resource)
+    {
+        $tag->setTagMetadata($metadata);
+        $resource->getTags()->add($tag);
+    }
 
     /**
      * Adds multiple tags on the given taggable resource
@@ -57,6 +72,23 @@ class TagManager
         foreach ($tags as $tag) {
             if ($tag instanceof Tag) {
                 $this->addTag($tag, $resource);
+            }
+        }
+    }
+    
+    /**
+     * Adds multiple tags on the given taggable resource and
+     * stores an additional temporary metadata object to each.
+     *
+     * @param Tag[]     $tags       Array of Tag objects
+     * @param Metadata  $metadata   TagMetadata object
+     * @param Taggable  $resource   Taggable resource
+     */
+    public function addTagsWithMetadata(array $tags, TagMetaData $metadata, Taggable $resource)
+    {
+        foreach ($tags as $tag) {
+            if ($tag instanceof Tag) {
+                $this->addTagWithMetadata($tag, $metadata, $resource);
             }
         }
     }
@@ -307,6 +339,16 @@ class TagManager
      */
     protected function createTagging(Tag $tag, Taggable $resource)
     {
-        return new $this->taggingClass($tag, $resource);
+        $tagging = new $this->taggingClass($tag, $resource);
+        if($metadump = $tag->getTagMetadata()) { 
+            foreach($metadump->dump() as $metadata)
+            { 
+                //Correlate it to a custom tagging metadata field and add the value.
+                $function = "setMetadata".$metadata['name'];
+                $tagging->$function($metadata['value']);
+            }
+        }
+        return $tagging;
+        
     }
 }


### PR DESCRIPTION
What's up Fabien?

To extend the usability of tags, I needed to store tag-resource specific information and to go about doing that, I added a couple changes to allow for the easy addition of metadata to the Tagging object. 

It's completely backwards compatible and requires very little to add metadata to tag objects:

```
$tag = $tag_manager->loadOrCreateTag('Blue');

$tag_metadata = new TagMetadata();
$tag_metadata->add("TagUser", $user);
$tag_metadata->add("IsMachine", false);

$tag_manager->addTagWithMetadata($tag, $tag_metadata, $resource);
$tag_manager->saveTagging($resource);
```

Because the metadata is stored in the Tagging table, the database schema will need to be updated accordingly with the metadata-enabled fields, prefixed with "metadata_" (e.g., 'metadata_tag_user', 'metadata_is_machine').

To retrieve metadata from a Tag: 
    $tag->getMetadata("TagUser");

This is definitely something up for discussion as it is a first run and quick bit addition, and probably could be improved. 
