### PR TITLE
Avoid Duplicate entry in db

### DIFF
--- a/lib/DoctrineExtensions/Taggable/TagManager.php
+++ b/lib/DoctrineExtensions/Taggable/TagManager.php
@@ -128,7 +128,7 @@ class TagManager
             $loadedNames[] = $tag->getName();
         }
 
-        $missingNames = array_diff($names, $loadedNames);
+        $missingNames = array_udiff($names, $loadedNames, 'strcasecmp');
         if (sizeof($missingNames)) {
             foreach ($missingNames as $name) {
                 $tag = $this->createTag($name);


### PR DESCRIPTION
If you already have a "jquery" tag and someone try to add a "jQuery" tag, there's an error :
Integrity constraint violation: 1062 Duplicate entry 'jQuery'

To avoid this error, Tag Manager now makes a case insensitive comparaison of the tag name.
