### PR TITLE
doctrine orm:validate-schema complaints about a missing inversed-by definition

### DIFF
--- a/metadata/DoctrineExtensions.Taggable.Entity.Tagging.dcm.xml
+++ b/metadata/DoctrineExtensions.Taggable.Entity.Tagging.dcm.xml
@@ -16,7 +16,7 @@
         <field name="createdAt"     column="created_at"     type="datetime" />
         <field name="updatedAt"     column="updated_at"     type="datetime" />
 
-        <many-to-one field="tag" target-entity="DoctrineExtensions\Taggable\Entity\Tag">
+        <many-to-one field="tag" target-entity="DoctrineExtensions\Taggable\Entity\Tag" inversed-by="tagging">
             <join-columns>
                 <join-column name="tag_id" referenced-column-name="id" />
             </join-columns>

--- a/tests/DoctrineExtensions/Taggable/TagManagerTest.php
+++ b/tests/DoctrineExtensions/Taggable/TagManagerTest.php
@@ -14,6 +14,7 @@ use DoctrineExtensions\Taggable\TagManager;
 use DoctrineExtensions\Taggable\TagListener;
 use DoctrineExtensions\Taggable\Entity\Tag;
 use Tests\DoctrineExtensions\Taggable\Fixtures\Article;
+use Doctrine\ORM\Tools\SchemaValidator;
 
 
 class TagManagerTest extends \PHPUnit_Framework_TestCase
@@ -317,5 +318,22 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
         $this->manager->addTags(array($tag2, $tag3), $article);
         $this->assertEquals(array('Smallville', 'Superman', 'TV'), $this->manager->getTagNames($article));
     }
+
+    /**
+     * checks for valid schema
+     */
+    public function testValidSchema()
+    {
+        $validator = new SchemaValidator($this->em);
+        $errors = $validator->validateClass($this->em->getClassMetadata('DoctrineExtensions\\Taggable\\Entity\\Tag'));
+        
+        if (count($errors) > 0) {
+            // Lots of errors!
+            echo PHP_EOL . implode("\n\n", $errors);
+        }
+
+        $this->assertEquals(0, count($errors));
+    }
+
 
 }


### PR DESCRIPTION
- add inversed-by="tagging" to Tag property on Tagging Entity
- add "test" which runs doctrine validate schema
