### PR TITLE
Flush only tags

### DIFF
--- a/lib/DoctrineExtensions/Taggable/TagManager.php
+++ b/lib/DoctrineExtensions/Taggable/TagManager.php
@@ -137,7 +137,7 @@ class TagManager
                 $tags[] = $tag;
             }
 
-            $this->em->flush();
+            $this->em->flush($tags);
         }
 
         return $tags;

--- a/lib/DoctrineExtensions/Taggable/TagManager.php
+++ b/lib/DoctrineExtensions/Taggable/TagManager.php
@@ -183,13 +183,17 @@ class TagManager
             }
         }
 
+        $toFlush = array();
         foreach ($tagsToAdd as $tag) {
             $this->em->persist($tag);
-            $this->em->persist($this->createTagging($tag, $resource));
+            $tagging = $this->createTagging($tag, $resource);
+            $this->em->persist($tagging);
+            $toFlush[] = $tag;
+            $toFlush[] = $tagging;
         }
 
         if (count($tagsToAdd)) {
-            $this->em->flush();
+            $this->em->flush($toFlush);
         }
     }
 


### PR DESCRIPTION
This pull request solve issue:

``` php
$user = $this->getUser();
$taggableRelation = new TaggableRelation();
$user->addTaggableRelation($taggableRelation);

$form = $this->createForm(new UserType(), $user);
$form->handleRequest($request); // form transformer is using loadOrCreateTags -> flush
```

this causes flush on user entity as well (without validation). 
