### PR TITLE
Update TagRepository.php

### DIFF
--- a/lib/DoctrineExtensions/Taggable/Entity/TagRepository.php
+++ b/lib/DoctrineExtensions/Taggable/Entity/TagRepository.php
@@ -89,7 +89,7 @@ class TagRepository extends EntityRepository
     public function getTagsWithCountArrayQueryBuilder($taggableType)
     {
         $qb = $this->getTagsQueryBuilder($taggableType)
-            ->groupBy('tagging.tag')
+            ->groupBy('tagging.tag, tag.'.$this->tagQueryField)
             ->select('tag.'.$this->tagQueryField.', COUNT(tagging.tag) as tag_count')
             ->orderBy('tag_count', 'DESC')
         ;


### PR DESCRIPTION
The column name was missing in the group by.

I got this error :

<code>
An exception occurred while executing 'SELECT c0_.name AS name0, COUNT(c1_.tag_id) AS sclr1 FROM Community c0_ INNER JOIN CommunitySubscribing c1_ ON c0_.id = c1_.tag_id WHERE c1_.resource_type = ? GROUP BY c1_.tag_id ORDER BY sclr1 DESC' with params ["theme"]:

SQLSTATE[42803]: Grouping error: 7 ERREUR: la colonne « c0_.name » doit apparaître dans la clause GROUP BY ou doit être utilisé dans une fonction d'agrégat
LINE 1: SELECT c0_.name AS name0, COUNT(c1_.tag_id) AS sclr1 FROM Co...
</code>

My modification fix this problem.
