### PR TITLE
The $newTags object should clone $resource tags collection.

### DIFF
--- a/lib/DoctrineExtensions/Taggable/TagManager.php
+++ b/lib/DoctrineExtensions/Taggable/TagManager.php
@@ -151,7 +151,7 @@ class TagManager
     public function saveTagging(Taggable $resource)
     {
         $oldTags = $this->getTagging($resource);
-        $newTags = $resource->getTags();
+        $newTags = clone $resource->getTags();
         $tagsToAdd = $newTags;
 
         if ($oldTags !== null and is_array($oldTags) and !empty($oldTags)) {

--- a/lib/DoctrineExtensions/Taggable/TagManager.php
+++ b/lib/DoctrineExtensions/Taggable/TagManager.php
@@ -128,7 +128,9 @@ class TagManager
             $loadedNames[] = $tag->getName();
         }
 
-        $missingNames = array_udiff($names, $loadedNames, 'strcasecmp');
+        $missingNames = array_udiff($names, $loadedNames, function ($str1, $str2) {
+            return strcmp(mb_strtolower($str1, 'UTF8'), mb_strtolower($str2, 'UTF8'));
+        });
         if (sizeof($missingNames)) {
             foreach ($missingNames as $name) {
                 $tag = $this->createTag($name);


### PR DESCRIPTION
The $newTags object should clone $resource tags collection.
For example we have a resource with tags 'aaa' ,'bbb';
Then we want to change tags to 'bbb', 'ccc';
$newTags = $resource->getTags();
$tagsToAdd = $newTags;
Then we remove 'bbb' tag from $tagsToAdd ($tagsToAdd->removeElement($oldTag)), because we don't need to add this tag, it already exists. But oops, it was also removed from $resource and the $resource->getTags() collection becomes not actual.
