### PR TITLE
Typehint `string` on `loadOrCreateTag`

### DIFF
--- a/lib/DoctrineExtensions/Taggable/TagManager.php
+++ b/lib/DoctrineExtensions/Taggable/TagManager.php
@@ -86,9 +86,9 @@ class TagManager
     }
 
     /**
-     * Loads or creates a tag from tag name
+     * Loads or creates a tag from tag name.
      *
-     * @param array  $name  Tag name
+     * @param string $name
      * @return Tag
      */
     public function loadOrCreateTag($name)


### PR DESCRIPTION
... as `TagManager` itself does put `name` in an array.

Right now PHPStorm triggers a warning on `loadOrCreateTag` because we send it a string. It actually should be typehinted as string, because the method wraps it in an array itself.