### PR TITLE
Fixed incorrect return type

### DIFF
--- a/lib/DoctrineExtensions/Taggable/Taggable.php
+++ b/lib/DoctrineExtensions/Taggable/Taggable.php
@@ -34,7 +34,7 @@ interface Taggable
     /**
      * Returns the collection of tags for this Taggable entity
      *
-     * @return Doctrine\Common\Collections\Collection
+     * @return \Doctrine\Common\Collections\Collection
      */
     function getTags();
 }


### PR DESCRIPTION
This results in an error in phpstan as the class can't be found (it looks in the current namespace)